### PR TITLE
changes handle `IO (Either a b)` properly

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,6 +6,7 @@ cli design
 -}
 module Main (main) where
 
+import Control.Monad
 import Control.Monad.Primitive
 import Data.List (isSuffixOf)
 import System.Directory
@@ -54,13 +55,7 @@ parseFile :: FilePath -> IO (Either ParserError WitFile)
 parseFile filepath = parse pWitFile filepath <$> readFile filepath
 
 checkFile :: FilePath -> IO ()
-checkFile filepath = do
-  parseFile filepath
-    >>= displayErr
-      ( \wit_file ->
-          check0 wit_file >>= displayErr touch show
-      )
-      errorBundlePretty
+checkFile = parseFile >=> displayErr (check0 >=> displayErr touch show) errorBundlePretty
 
 displayErr :: (a -> IO ()) -> (e -> String) -> Either e a -> IO ()
 displayErr f showE = \case

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -33,7 +33,7 @@ handle ["instance", mode, file] = do
     "import" -> do
       parseFile file
         -- TODO: output to somewhere file
-        >>= displayErr (putStrLn . genInstanceImport) errorBundlePretty
+        >>= displayIOLeft errorBundlePretty (putStrLn . genInstanceImport)
       return ()
     "export" -> return ()
     bad -> putStrLn $ "unknown option: " ++ bad
@@ -43,7 +43,7 @@ handle ["runtime", mode, file] =
     "export" -> do
       parseFile file
         -- TODO: output to somewhere file
-        >>= displayErr (putStrLn . genRuntimeExport) errorBundlePretty
+        >>= displayIOLeft errorBundlePretty (putStrLn . genRuntimeExport)
       return ()
     bad -> putStrLn $ "unknown option: " ++ bad
 handle _ = putStrLn "bad usage"
@@ -55,9 +55,9 @@ parseFile :: FilePath -> IO (Either ParserError WitFile)
 parseFile filepath = parse pWitFile filepath <$> readFile filepath
 
 checkFile :: FilePath -> IO ()
-checkFile = parseFile >=> displayErr (check0 >=> displayErr touch show) errorBundlePretty
+checkFile = parseFile >=> displayIOLeft errorBundlePretty (check0 >=> displayIOLeft show touch)
 
-displayErr :: (a -> IO ()) -> (e -> String) -> Either e a -> IO ()
-displayErr f showE = \case
+displayIOLeft :: (e -> String) -> (a -> IO ()) -> Either e a -> IO ()
+displayIOLeft showE f = \case
   Left e -> putStrLn $ showE e
   Right a -> f a

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ dependencies:
   - base >= 4.7 && < 5
   - mtl
   - transformers
+  - primitive
   - directory
   - megaparsec
 

--- a/src/Wit/Check.hs
+++ b/src/Wit/Check.hs
@@ -1,20 +1,27 @@
 module Wit.Check
-  ( check0,
+  ( CheckError,
+    check0,
   )
 where
 
 import System.Directory
-import Text.Megaparsec (SourcePos)
+import Text.Megaparsec
 import Wit.Ast
 
-type M = Either (String, Maybe SourcePos)
+data CheckError = CheckError String (Maybe SourcePos)
+
+instance Show CheckError where
+  show (CheckError msg (Just pos)) = sourcePosPretty pos ++ ": " ++ msg
+  show (CheckError msg Nothing) = msg
+
+type M = Either CheckError
 
 report :: String -> M a
-report msg = Left (msg, Nothing)
+report msg = Left $ CheckError msg Nothing
 
 addPos :: SourcePos -> M a -> M a
 addPos pos ma = case ma of
-  Left (msg, Nothing) -> Left (msg, Just pos)
+  Left (CheckError msg Nothing) -> Left (CheckError msg (Just pos))
   ma' -> ma'
 
 type Name = String

--- a/src/Wit/Parser.hs
+++ b/src/Wit/Parser.hs
@@ -1,5 +1,7 @@
 module Wit.Parser
-  ( -- file level parser
+  ( -- parser error for this module
+    ParserError,
+    -- file level parser
     pWitFile,
     -- Use statement
     pUse,
@@ -26,6 +28,8 @@ import Text.Megaparsec.Char.Lexer qualified as L
 import Wit.Ast
 
 type Parser = Parsec Void String
+
+type ParserError = ParseErrorBundle String Void
 
 pWitFile :: Parser WitFile
 pWitFile = do
@@ -118,14 +122,7 @@ pEnum = do
   return $ Enum name case_list
 
 pType :: Parser Type
-pType =
-  choice
-    [ expectedTy,
-      tupleTy,
-      listTy,
-      optionalTy,
-      primitiveTy
-    ]
+pType = choice [expectedTy, tupleTy, listTy, optionalTy, primitiveTy] <?> "<type>"
   where
     expectedTy, tupleTy, listTy, optionalTy, primitiveTy :: Parser Type
     expectedTy = do

--- a/test/Wit/CheckSpec.hs
+++ b/test/Wit/CheckSpec.hs
@@ -11,9 +11,9 @@ spec = describe "check wit" $ do
     it "should report undefined type" $ do
       contents <- readFile "test/slight-samples/bad-types.wit"
       case runParser pWitFile "" contents of
-        Left bundle -> putStrLn $ "fail: " ++ errorBundlePretty bundle
+        Left _bundle -> return ()
         Right wit_file -> do
           r <- check0 wit_file
           case r of
-            Left (_msg, _pos) -> return ()
+            Left _ -> return ()
             Right _ -> expectationFailure "checker should find out undefined type!"

--- a/witc.cabal
+++ b/witc.cabal
@@ -47,6 +47,7 @@ library
     , directory
     , megaparsec
     , mtl
+    , primitive
     , transformers
   default-language: Haskell2010
 
@@ -67,6 +68,7 @@ executable witc-exe
     , directory
     , megaparsec
     , mtl
+    , primitive
     , transformers
     , witc
   default-language: Haskell2010
@@ -93,6 +95,7 @@ test-suite witc-test
     , hspec-megaparsec
     , megaparsec
     , mtl
+    , primitive
     , transformers
     , witc
   default-language: Haskell2010


### PR DESCRIPTION
* improve parser error via `<?>` hint
* print check error with position
    TODO here is type non-exist error should point to usage position directly, hence, type should attach a position for reporting

Signed-off-by: Lîm Tsú-thuàn <dannypsnl@secondstate.io>