### PR TITLE
runtime export

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,8 +15,8 @@ import System.Exit (exitSuccess)
 import Text.Megaparsec
 import Wit.Ast
 import Wit.Check
-import Wit.Gen.Import
-import Wit.Parser
+import Wit.Gen
+import Wit.Parser (ParserError, pWitFile)
 
 main :: IO ()
 main = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -54,7 +54,7 @@ parseFile filepath = do
     Left e -> return $ Left (PErr e)
     Right ast -> return $ Right ast
 
-checkFile :: FilePath -> IO WitFile
+checkFile :: FilePath -> IO (WitFile, Env)
 checkFile = parseFile >=> eitherIO (check0 >=> eitherIO return)
 
 eitherIO :: Show e => (a -> IO b) -> Either e a -> IO b

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -31,28 +31,21 @@ handle ["check"] = do
   mapM_ checkFile $ filter (".wit" `isSuffixOf`) fileList
 handle ["instance", mode, file] = do
   case mode of
-    "import" -> do
+    "import" ->
       parseFile file
         >>= eitherIO check0
-        -- TODO: output to somewhere file
         >>= eitherIO renderInstanceImport
-      return ()
-    "export" -> return ()
+    "export" -> error "unsupported instance export yet"
     bad -> putStrLn $ "unknown option: " ++ bad
 handle ["runtime", mode, file] =
   case mode of
-    "import" -> return ()
-    "export" -> do
+    "import" -> error "unsupported runtime import yet"
+    "export" ->
       parseFile file
         >>= eitherIO check0
-        -- TODO: output to somewhere file
-        >>= eitherIO (putStrLn . genRuntimeExport)
-      return ()
+        >>= eitherIO renderRuntimeExport
     bad -> putStrLn $ "unknown option: " ++ bad
 handle _ = putStrLn "bad usage"
-
-genRuntimeExport :: WitFile -> String
-genRuntimeExport _ = ""
 
 parseFile :: FilePath -> IO (Either FuseError WitFile)
 parseFile filepath = do

--- a/example/WitTest/Cargo.lock
+++ b/example/WitTest/Cargo.lock
@@ -111,6 +111,7 @@ version = "0.1.0"
 dependencies = [
  "abi",
  "anyhow",
+ "pmacro",
  "wasmedge-sdk",
 ]
 

--- a/example/WitTest/host/Cargo.toml
+++ b/example/WitTest/host/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 wasmedge-sdk = "0.7.1"
 abi = { path = "../abi" }
 anyhow = "*"
+pmacro = { path = "../pmacro" }

--- a/example/WitTest/pmacro/src/lib.rs
+++ b/example/WitTest/pmacro/src/lib.rs
@@ -12,3 +12,14 @@ pub fn wit_instance_import(input: TokenStream) -> TokenStream {
         .unwrap();
     String::from_utf8_lossy(&r.stdout).parse().unwrap()
 }
+
+#[proc_macro]
+pub fn wit_runtime_export(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as LitStr);
+    let wit_file = input.value();
+    let r = Command::new("witc-exe")
+        .args(["runtime", "export", &wit_file])
+        .output()
+        .unwrap();
+    String::from_utf8_lossy(&r.stdout).parse().unwrap()
+}

--- a/src/Wit/Ast.hs
+++ b/src/Wit/Ast.hs
@@ -85,4 +85,6 @@ data Type
   | ExpectedTy Type Type
   | TupleTy [Type]
   | User String -- user defined types
+  -- in execution only
+  | VSum String [Type]
   deriving (Show)

--- a/src/Wit/Gen.hs
+++ b/src/Wit/Gen.hs
@@ -1,0 +1,55 @@
+module Wit.Gen
+  ( renderInstanceImport,
+    renderRuntimeExport,
+  )
+where
+
+import Data.List (partition)
+import Prettyprinter
+import Prettyprinter.Render.Text
+import Wit.Ast
+import Wit.Check
+import Wit.Gen.Export
+import Wit.Gen.Import
+import Wit.Gen.Type
+
+renderInstanceImport :: (WitFile, Env) -> IO ()
+renderInstanceImport (f, env) = putDoc $ prettyFile Config {language = Rust, direction = Import, side = Instance} f env
+
+renderRuntimeExport :: (WitFile, Env) -> IO ()
+renderRuntimeExport (f, env) = putDoc $ prettyFile Config {language = Rust, direction = Export, side = Runtime} f env
+
+data SupportedLanguage
+  = Rust
+
+data Direction
+  = Import
+  | Export
+
+data Side
+  = Instance
+  | Runtime
+
+data Config = Config
+  { language :: SupportedLanguage,
+    direction :: Direction,
+    side :: Side
+  }
+
+prettyFile :: Config -> WitFile -> Env -> Doc a
+prettyFile config WitFile {definition_list = def_list} env =
+  let (ty_defs, defs) = partition isTypeDef def_list
+   in case (config.side, config.direction) of
+        (Instance, Import) ->
+          vsep (map prettyTypeDef ty_defs)
+            <+> line
+            <+> pretty "#[link(wasm_import_module = \"wasmedge\")]"
+            <+> line
+            <+> pretty "extern \"wasm\""
+            <+> braces (line <+> indent 4 (vsep (map prettyDefExtern defs)) <+> line)
+            <+> line
+            <+> vsep (map prettyDefWrap defs)
+        (Runtime, Export) ->
+          vsep (map prettyTypeDef ty_defs)
+            <+> witObject env defs
+        (_, _) -> error "unsupported side, direction combination"

--- a/src/Wit/Gen/Export.hs
+++ b/src/Wit/Gen/Export.hs
@@ -55,16 +55,15 @@ witObject env defs =
     withFunc :: Definition -> Doc a
     withFunc (SrcPos _ d) = withFunc d
     withFunc (Func (Function _attr name params result_ty)) =
-      let nname = normalizeIdentifier name
-       in pretty ".with_func::"
-            <+> angles
-              ( prettyEnc (sum $ map (i32Encoding Nothing . snd) params)
-                  <+> comma
-                  <+> prettyEnc (i32Encoding Nothing result_ty)
-              )
-            <+> tupled
-              [ dquotes $ hcat [pretty "extern_", pretty nname],
-                pretty nname
-              ]
-            <+> pretty "?"
+      pretty ".with_func::"
+        <+> angles
+          ( prettyEnc (sum $ map (i32Encoding Nothing . snd) params)
+              <+> comma
+              <+> prettyEnc (i32Encoding Nothing result_ty)
+          )
+        <+> tupled
+          [ dquotes $ pretty $ externalConvention name,
+            pretty $ normalizeIdentifier name
+          ]
+        <+> pretty "?"
     withFunc d = error $ "bad definition" ++ show d

--- a/src/Wit/Gen/Export.hs
+++ b/src/Wit/Gen/Export.hs
@@ -1,0 +1,70 @@
+module Wit.Gen.Export
+  ( witObject,
+  )
+where
+
+import Data.Maybe
+import Prettyprinter
+import Wit.Ast
+import Wit.Check
+import Wit.Gen.Normalization
+
+witObject :: Env -> [Definition] -> Doc a
+witObject env defs =
+  pretty "fn wit_import_object() -> wasmedge_sdk::WasmEdgeResult<wasmedge_sdk::ImportObject>"
+    <+> braces
+      ( pretty "Ok"
+          <+> parens
+            ( pretty "wasmedge_sdk::ImportObjectBuilder::new()"
+                <+> vsep (map withFunc defs)
+                <+> pretty ".build(\"wasmedge\")?"
+            )
+      )
+  where
+    i32Encoding :: Maybe String -> Type -> Int
+    i32Encoding n (SrcPosType _ ty) = i32Encoding n ty
+    i32Encoding _n PrimString = 3
+    i32Encoding _n PrimU8 = 1
+    i32Encoding _n PrimU16 = 1
+    i32Encoding _n PrimU32 = 1
+    i32Encoding _n PrimU64 = 1
+    i32Encoding _n PrimI8 = 1
+    i32Encoding _n PrimI16 = 1
+    i32Encoding _n PrimI32 = 1
+    i32Encoding _n PrimI64 = 1
+    i32Encoding _n PrimChar = 1
+    i32Encoding _n PrimF32 = 1
+    i32Encoding _n PrimF64 = 1
+    i32Encoding n (Optional ty) = 1 + i32Encoding n ty
+    i32Encoding _n (ListTy _ty) = 3
+    i32Encoding n (ExpectedTy a b) = 1 + (i32Encoding n a `max` i32Encoding n b)
+    i32Encoding n (TupleTy ty_list) = sum $ map (i32Encoding n) ty_list
+    i32Encoding Nothing (User name) = i32Encoding Nothing $ fromJust $ lookupEnv name env
+    i32Encoding (Just n) (User name) =
+      if n == name
+        then 1
+        else i32Encoding (Just n) $ fromJust $ lookupEnv name env
+    -- execution
+    i32Encoding _ (VSum name ty_list) = foldl max 0 (map (i32Encoding $ Just name) ty_list) + 1
+
+    prettyEnc :: Int -> Doc a
+    prettyEnc 0 = pretty "()"
+    prettyEnc 1 = pretty "i32"
+    prettyEnc n = tupled $ replicate n (pretty "i32")
+
+    withFunc :: Definition -> Doc a
+    withFunc (SrcPos _ d) = withFunc d
+    withFunc (Func (Function _attr name params result_ty)) =
+      let nname = normalizeIdentifier name
+       in pretty ".with_func::"
+            <+> angles
+              ( prettyEnc (sum $ map (i32Encoding Nothing . snd) params)
+                  <+> comma
+                  <+> prettyEnc (i32Encoding Nothing result_ty)
+              )
+            <+> tupled
+              [ dquotes $ hcat [pretty "extern_", pretty nname],
+                pretty nname
+              ]
+            <+> pretty "?"
+    withFunc d = error $ "bad definition" ++ show d

--- a/src/Wit/Gen/Import.hs
+++ b/src/Wit/Gen/Import.hs
@@ -35,7 +35,7 @@ prettyDefExtern :: Definition -> Doc a
 prettyDefExtern (SrcPos _ d) = prettyDefExtern d
 prettyDefExtern (Resource _name _) = undefined
 prettyDefExtern (Func (Function _attr name param_list result_ty)) =
-  hsep (map pretty ["fn", "extern_" ++ normalizeIdentifier name])
+  hsep (map pretty ["fn", externalConvention name])
     <+> parens (hsep $ punctuate comma (map prettyABIBinder param_list))
     <+> pretty "->"
     <+> prettyABIType result_ty

--- a/src/Wit/Gen/Import.hs
+++ b/src/Wit/Gen/Import.hs
@@ -1,118 +1,14 @@
 module Wit.Gen.Import
-  ( renderInstanceImport,
-    renderRuntimeExport,
+  ( prettyDefWrap,
+    prettyDefExtern,
+    isTypeDef,
   )
 where
 
-import Data.List (partition)
-import Data.Maybe
 import Prettyprinter
-import Prettyprinter.Render.Text
 import Wit.Ast
-import Wit.Check
 import Wit.Gen.Normalization
 import Wit.Gen.Type
-
-renderInstanceImport :: (WitFile, Env) -> IO ()
-renderInstanceImport (f, env) = putDoc $ prettyFile Config {language = Rust, direction = Import, side = Instance} f env
-
-renderRuntimeExport :: (WitFile, Env) -> IO ()
-renderRuntimeExport (f, env) = putDoc $ prettyFile Config {language = Rust, direction = Export, side = Runtime} f env
-
-data SupportedLanguage
-  = Rust
-
-data Direction
-  = Import
-  | Export
-
-data Side
-  = Instance
-  | Runtime
-
-data Config = Config
-  { language :: SupportedLanguage,
-    direction :: Direction,
-    side :: Side
-  }
-
-prettyFile :: Config -> WitFile -> Env -> Doc a
-prettyFile config WitFile {definition_list = def_list} env =
-  let (ty_defs, defs) = partition isTypeDef def_list
-   in case (config.side, config.direction) of
-        (Instance, Import) ->
-          vsep (map prettyTypeDef ty_defs)
-            <+> line
-            <+> pretty "#[link(wasm_import_module = \"wasmedge\")]"
-            <+> line
-            <+> pretty "extern \"wasm\""
-            <+> braces (line <+> indent 4 (vsep (map prettyDefExtern defs)) <+> line)
-            <+> line
-            <+> vsep (map prettyDefWrap defs)
-        (Runtime, Export) ->
-          vsep (map prettyTypeDef ty_defs)
-            <+> witObject env defs
-        (_, _) -> error "unsupported side, direction combination"
-
-witObject :: Env -> [Definition] -> Doc a
-witObject env defs =
-  pretty "fn wit_import_object() -> wasmedge_sdk::WasmEdgeResult<wasmedge_sdk::ImportObject>"
-    <+> braces
-      ( pretty "Ok"
-          <+> parens
-            ( pretty "wasmedge_sdk::ImportObjectBuilder::new()"
-                <+> vsep (map withFunc defs)
-                <+> pretty ".build(\"wasmedge\")?"
-            )
-      )
-  where
-    i32Encoding :: Maybe String -> Type -> Int
-    i32Encoding n (SrcPosType _ ty) = i32Encoding n ty
-    i32Encoding _n PrimString = 3
-    i32Encoding _n PrimU8 = 1
-    i32Encoding _n PrimU16 = 1
-    i32Encoding _n PrimU32 = 1
-    i32Encoding _n PrimU64 = 1
-    i32Encoding _n PrimI8 = 1
-    i32Encoding _n PrimI16 = 1
-    i32Encoding _n PrimI32 = 1
-    i32Encoding _n PrimI64 = 1
-    i32Encoding _n PrimChar = 1
-    i32Encoding _n PrimF32 = 1
-    i32Encoding _n PrimF64 = 1
-    i32Encoding n (Optional ty) = 1 + i32Encoding n ty
-    i32Encoding _n (ListTy _ty) = 3
-    i32Encoding n (ExpectedTy a b) = 1 + (i32Encoding n a `max` i32Encoding n b)
-    i32Encoding n (TupleTy ty_list) = sum $ map (i32Encoding n) ty_list
-    i32Encoding Nothing (User name) = i32Encoding Nothing $ fromJust $ lookupEnv name env
-    i32Encoding (Just n) (User name) =
-      if n == name
-        then 1
-        else i32Encoding (Just n) $ fromJust $ lookupEnv name env
-    -- execution
-    i32Encoding _ (VSum name ty_list) = foldl max 0 (map (i32Encoding $ Just name) ty_list) + 1
-
-    g :: [Type] -> Type -> (Int, Int)
-    g param_types r_ty = (sum $ map (i32Encoding Nothing) param_types, i32Encoding Nothing r_ty)
-
-    prettyEnc :: Int -> Doc a
-    prettyEnc 0 = pretty "()"
-    prettyEnc 1 = pretty "i32"
-    prettyEnc n = tupled $ replicate n (pretty "i32")
-
-    withFunc :: Definition -> Doc a
-    withFunc (SrcPos _ d) = withFunc d
-    withFunc (Func (Function _attr name params result_ty)) =
-      let nname = normalizeIdentifier name
-       in let (n, m) = g (map snd params) result_ty
-           in pretty ".with_func::"
-                <+> angles (prettyEnc n <+> comma <+> prettyEnc m)
-                <+> tupled
-                  [ dquotes $ hcat [pretty "extern_", pretty nname],
-                    pretty nname
-                  ]
-                <+> pretty "?"
-    withFunc d = error $ "bad definition" ++ show d
 
 prettyDefWrap :: Definition -> Doc a
 prettyDefWrap (SrcPos _ d) = prettyDefWrap d

--- a/src/Wit/Gen/Import.hs
+++ b/src/Wit/Gen/Import.hs
@@ -5,17 +5,19 @@ module Wit.Gen.Import
 where
 
 import Data.List (partition)
+import Data.Maybe
 import Prettyprinter
 import Prettyprinter.Render.Text
 import Wit.Ast
+import Wit.Check
 import Wit.Gen.Normalization
 import Wit.Gen.Type
 
-renderInstanceImport :: WitFile -> IO ()
-renderInstanceImport f = putDoc $ prettyFile Config {language = Rust, direction = Import, side = Instance} f
+renderInstanceImport :: (WitFile, Env) -> IO ()
+renderInstanceImport (f, env) = putDoc $ prettyFile Config {language = Rust, direction = Import, side = Instance} f env
 
-renderRuntimeExport :: WitFile -> IO ()
-renderRuntimeExport f = putDoc $ prettyFile Config {language = Rust, direction = Export, side = Runtime} f
+renderRuntimeExport :: (WitFile, Env) -> IO ()
+renderRuntimeExport (f, env) = putDoc $ prettyFile Config {language = Rust, direction = Export, side = Runtime} f env
 
 data SupportedLanguage
   = Rust
@@ -34,8 +36,8 @@ data Config = Config
     side :: Side
   }
 
-prettyFile :: Config -> WitFile -> Doc a
-prettyFile config WitFile {definition_list = def_list} =
+prettyFile :: Config -> WitFile -> Env -> Doc a
+prettyFile config WitFile {definition_list = def_list} env =
   let (ty_defs, defs) = partition isTypeDef def_list
    in case (config.side, config.direction) of
         (Instance, Import) ->
@@ -49,7 +51,68 @@ prettyFile config WitFile {definition_list = def_list} =
             <+> vsep (map prettyDefWrap defs)
         (Runtime, Export) ->
           vsep (map prettyTypeDef ty_defs)
+            <+> witObject env defs
         (_, _) -> error "unsupported side, direction combination"
+
+witObject :: Env -> [Definition] -> Doc a
+witObject env defs =
+  pretty "fn wit_import_object() -> wasmedge_sdk::WasmEdgeResult<wasmedge_sdk::ImportObject>"
+    <+> braces
+      ( pretty "Ok"
+          <+> parens
+            ( pretty "wasmedge_sdk::ImportObjectBuilder::new()"
+                <+> vsep (map withFunc defs)
+                <+> pretty ".build(\"wasmedge\")?"
+            )
+      )
+  where
+    i32Encoding :: Maybe String -> Type -> Int
+    i32Encoding n (SrcPosType _ ty) = i32Encoding n ty
+    i32Encoding _n PrimString = 3
+    i32Encoding _n PrimU8 = 1
+    i32Encoding _n PrimU16 = 1
+    i32Encoding _n PrimU32 = 1
+    i32Encoding _n PrimU64 = 1
+    i32Encoding _n PrimI8 = 1
+    i32Encoding _n PrimI16 = 1
+    i32Encoding _n PrimI32 = 1
+    i32Encoding _n PrimI64 = 1
+    i32Encoding _n PrimChar = 1
+    i32Encoding _n PrimF32 = 1
+    i32Encoding _n PrimF64 = 1
+    i32Encoding n (Optional ty) = 1 + i32Encoding n ty
+    i32Encoding _n (ListTy _ty) = 3
+    i32Encoding n (ExpectedTy a b) = 1 + (i32Encoding n a `max` i32Encoding n b)
+    i32Encoding n (TupleTy ty_list) = sum $ map (i32Encoding n) ty_list
+    i32Encoding Nothing (User name) = i32Encoding Nothing $ fromJust $ lookupEnv name env
+    i32Encoding (Just n) (User name) =
+      if n == name
+        then 1
+        else i32Encoding (Just n) $ fromJust $ lookupEnv name env
+    -- execution
+    i32Encoding _ (VSum name ty_list) = foldl max 0 (map (i32Encoding $ Just name) ty_list) + 1
+
+    g :: [Type] -> Type -> (Int, Int)
+    g param_types r_ty = (sum $ map (i32Encoding Nothing) param_types, i32Encoding Nothing r_ty)
+
+    prettyEnc :: Int -> Doc a
+    prettyEnc 0 = pretty "()"
+    prettyEnc 1 = pretty "i32"
+    prettyEnc n = tupled $ replicate n (pretty "i32")
+
+    withFunc :: Definition -> Doc a
+    withFunc (SrcPos _ d) = withFunc d
+    withFunc (Func (Function _attr name params result_ty)) =
+      let nname = normalizeIdentifier name
+       in let (n, m) = g (map snd params) result_ty
+           in pretty ".with_func::"
+                <+> angles (prettyEnc n <+> comma <+> prettyEnc m)
+                <+> tupled
+                  [ dquotes $ hcat [pretty "extern_", pretty nname],
+                    pretty nname
+                  ]
+                <+> pretty "?"
+    withFunc d = error $ "bad definition" ++ show d
 
 prettyDefWrap :: Definition -> Doc a
 prettyDefWrap (SrcPos _ d) = prettyDefWrap d

--- a/src/Wit/Gen/Normalization.hs
+++ b/src/Wit/Gen/Normalization.hs
@@ -1,7 +1,11 @@
 module Wit.Gen.Normalization
   ( normalizeIdentifier,
+    externalConvention,
   )
 where
+
+externalConvention :: String -> String
+externalConvention s = "extern_" ++ normalizeIdentifier s
 
 normalizeIdentifier :: String -> String
 normalizeIdentifier = map f

--- a/src/Wit/Gen/Type.hs
+++ b/src/Wit/Gen/Type.hs
@@ -80,6 +80,7 @@ prettyType (ExpectedTy ty ety) =
   hsep [pretty "Result<", prettyType ty, pretty ",", prettyType ety, pretty ">"]
 prettyType (TupleTy ty_list) = parens (hsep $ punctuate comma (map prettyType ty_list))
 prettyType (User name) = pretty name
+prettyType _ = error "impossible"
 
 prettyABIType :: Type -> Doc a
 prettyABIType (SrcPosType _ ty) = prettyABIType ty

--- a/witc.cabal
+++ b/witc.cabal
@@ -29,6 +29,8 @@ library
       Wit
       Wit.Ast
       Wit.Check
+      Wit.Gen
+      Wit.Gen.Export
       Wit.Gen.Import
       Wit.Gen.Normalization
       Wit.Gen.Type


### PR DESCRIPTION
- generate `ImportObject`
   - convert wit types to `i32` encoding
- extern naming convention